### PR TITLE
feature/w98-0056: mf-color-generator - copy color

### DIFF
--- a/core/internationalization/i18n/src/locales/micro-frontends/de/mf-color-generator.locale.json
+++ b/core/internationalization/i18n/src/locales/micro-frontends/de/mf-color-generator.locale.json
@@ -3,6 +3,7 @@
 		"title": "Farbgenerator",
 		"hex": "HEX",
 		"rgb": "RGB",
-		"generate-button": "Generieren"
+		"generate-button": "Generieren",
+		"copy": "Kopieren"
 	}
 }

--- a/core/internationalization/i18n/src/locales/micro-frontends/en/mf-color-generator.locale.json
+++ b/core/internationalization/i18n/src/locales/micro-frontends/en/mf-color-generator.locale.json
@@ -3,6 +3,7 @@
 		"title": "Color Generator",
 		"hex": "HEX",
 		"rgb": "RGB",
-		"generate-button": "Generate"
+		"generate-button": "Generate",
+		"copy": "Copy"
 	}
 }

--- a/core/internationalization/i18n/src/locales/micro-frontends/pl/mf-color-generator.locale.json
+++ b/core/internationalization/i18n/src/locales/micro-frontends/pl/mf-color-generator.locale.json
@@ -3,6 +3,7 @@
 		"title": "Generator Kolorów",
 		"hex": "HEX",
 		"rgb": "RGB",
-		"generate-button": "Generuj"
+		"generate-button": "Generuj",
+		"copy": "Kopiuj"
 	}
 }

--- a/micro-frontends/src/mf-color-generator/src/domain/contracts/domain.contract.ts
+++ b/micro-frontends/src/mf-color-generator/src/domain/contracts/domain.contract.ts
@@ -3,4 +3,6 @@ import type { ColorState } from "../models"
 export interface ColorGeneratorDomainContract {
 	currentColor: ColorState
 	generateRandomColor(): void
+	copyHexColor(): Promise<void>
+	copyRgbColor(): Promise<void>
 }

--- a/micro-frontends/src/mf-color-generator/src/domain/domains/color-generator.domain.ts
+++ b/micro-frontends/src/mf-color-generator/src/domain/domains/color-generator.domain.ts
@@ -1,4 +1,5 @@
 import { MSColorGenerator } from "@windows98/micro-services"
+import { MSClipboard } from "@windows98/micro-services"
 import { makeAutoObservable } from "mobx"
 import type { ColorGeneratorDomainContract } from "../contracts"
 import type { ColorState } from "../models"
@@ -6,6 +7,16 @@ import type { ColorState } from "../models"
 export class ColorGeneratorDomain implements ColorGeneratorDomainContract {
 	private msColorGenerator: typeof MSColorGenerator
 	public currentColor: ColorState
+
+	public copyHexColor = async (): Promise<void> => {
+		await MSClipboard.copyText(this.currentColor.hex)
+	}
+
+	public copyRgbColor = async (): Promise<void> => {
+		const { r, g, b } = this.currentColor.rgb
+		const rgbString = `rgb(${r}, ${g}, ${b})`
+		await MSClipboard.copyText(rgbString)
+	}
 
 	constructor() {
 		makeAutoObservable(this)

--- a/micro-frontends/src/mf-color-generator/src/ui/modules/hex-input/hex-input.tsx
+++ b/micro-frontends/src/mf-color-generator/src/ui/modules/hex-input/hex-input.tsx
@@ -1,18 +1,25 @@
-import { DSInput } from "@windows98/design-system"
+import { DSButton, DSInput } from "@windows98/design-system"
 import { observer } from "mobx-react-lite"
 import type { FunctionComponent } from "react"
 import { useHexInput } from "./use-hex-input.hook"
 
 export const HexInput: FunctionComponent = observer(() => {
-	const { currentColor, translations } = useHexInput()
+	const { currentColor, translations, copyHexColor } = useHexInput()
 
 	return (
-		<DSInput
-			id="mf-color-generator-hex-color"
-			labelName={translations.label}
-			initialValue={currentColor.hex}
-			readonly={true}
-			wrapperLayout="vertical"
-		/>
+		<>
+			<DSInput
+				id="mf-color-generator-hex-color"
+				labelName={translations.label}
+				initialValue={currentColor.hex}
+				readonly={true}
+				wrapperLayout="vertical"
+			/>
+			<DSButton
+				id="mf-color-generator-copy-hex"
+				text={translations.copy}
+				onClick={copyHexColor}
+			/>
+		</>
 	)
 })

--- a/micro-frontends/src/mf-color-generator/src/ui/modules/hex-input/use-hex-input.hook.ts
+++ b/micro-frontends/src/mf-color-generator/src/ui/modules/hex-input/use-hex-input.hook.ts
@@ -7,10 +7,12 @@ export const useHexInput = () => {
 
 	const translations = {
 		label: t("mf-color-generator.hex"),
+		copy: t("mf-color-generator.copy"),
 	}
 
 	return {
 		currentColor: domain.currentColor,
 		translations,
+		copyHexColor: domain.copyHexColor,
 	}
 }

--- a/micro-frontends/src/mf-color-generator/src/ui/modules/modal/modal.tsx
+++ b/micro-frontends/src/mf-color-generator/src/ui/modules/modal/modal.tsx
@@ -13,7 +13,7 @@ export const Modal: FunctionComponent<ModalProps> = ({ children }) => {
 			onClose={onCloseProgram}
 			title={translations.title}
 			width="300px"
-			height="200px"
+			height="250px"
 		>
 			{children}
 		</DSModal>

--- a/micro-frontends/src/mf-color-generator/src/ui/modules/rgb-input/rgb-input.tsx
+++ b/micro-frontends/src/mf-color-generator/src/ui/modules/rgb-input/rgb-input.tsx
@@ -1,18 +1,25 @@
-import { DSInput } from "@windows98/design-system"
+import { DSButton, DSInput } from "@windows98/design-system"
 import { observer } from "mobx-react-lite"
 import type { FunctionComponent } from "react"
 import { useRgbInput } from "./use-rgb-input.hook"
 
 export const RgbInput: FunctionComponent = observer(() => {
-	const { translations, rgbValue } = useRgbInput()
+	const { translations, rgbValue, copyRgbColor } = useRgbInput()
 
 	return (
-		<DSInput
-			id="mf-color-generator-rgb-color"
-			labelName={translations.label}
-			initialValue={rgbValue}
-			readonly={true}
-			wrapperLayout="vertical"
-		/>
+		<>
+			<DSInput
+				id="mf-color-generator-rgb-color"
+				labelName={translations.label}
+				initialValue={rgbValue}
+				readonly={true}
+				wrapperLayout="vertical"
+			/>
+			<DSButton
+				id="mf-color-generator-copy-rgb"
+				text={translations.copy}
+				onClick={copyRgbColor}
+			/>
+		</>
 	)
 })

--- a/micro-frontends/src/mf-color-generator/src/ui/modules/rgb-input/use-rgb-input.hook.ts
+++ b/micro-frontends/src/mf-color-generator/src/ui/modules/rgb-input/use-rgb-input.hook.ts
@@ -7,6 +7,7 @@ export const useRgbInput = () => {
 
 	const translations = {
 		label: t("mf-color-generator.rgb"),
+		copy: t("mf-color-generator.copy"),
 	}
 
 	const rgbValue = `rgb(${domain.currentColor.rgb.r}, ${domain.currentColor.rgb.g}, ${domain.currentColor.rgb.b})`
@@ -15,5 +16,6 @@ export const useRgbInput = () => {
 		currentColor: domain.currentColor,
 		translations,
 		rgbValue,
+		copyRgbColor: domain.copyRgbColor,
 	}
 }

--- a/micro-frontends/src/mf-color-generator/src/ui/modules/wrapper/wrapper.module.css
+++ b/micro-frontends/src/mf-color-generator/src/ui/modules/wrapper/wrapper.module.css
@@ -1,14 +1,33 @@
 .wrapper {
 	display: grid;
-	grid-template-columns: 1fr 1fr;
-	grid-template-rows: auto auto auto;
-	gap: var(--ds-spacing-md);
+	grid-template-columns: repeat(2, auto);
+	grid-template-rows: repeat(3, auto);
+	gap: var(--ds-spacing-lg);
 	padding: var(--ds-spacing-md);
 	place-items: center;
+	align-items: end;
 }
 
 .wrapper > :first-child {
 	grid-column: 1 / -1;
+}
+
+.wrapper > :nth-child(2) {
+	grid-column: 1;
+	margin-left: auto;
+}
+.wrapper > :nth-child(3) {
+	grid-column: 2;
+	margin-right: auto;
+}
+
+.wrapper > :nth-child(4) {
+	grid-column: 1;
+	margin-left: auto;
+}
+.wrapper > :nth-child(5) {
+	grid-column: 2;
+	margin-right: auto;
 }
 
 .wrapper > :last-child {

--- a/micro-frontends/src/mf-color-generator/tests/ui/color-generator.test.tsx
+++ b/micro-frontends/src/mf-color-generator/tests/ui/color-generator.test.tsx
@@ -91,4 +91,38 @@ test.describe("ColorGenerator", () => {
 			"Color box should have background color applied",
 		).toBeTruthy()
 	})
+
+	test("should copy hex and rgb color to clipboard", async ({
+		mount,
+		context,
+		page,
+	}) => {
+		await context.grantPermissions(["clipboard-read", "clipboard-write"])
+		const component = await mount(
+			<MFColorGenerator onCloseProgram={() => {}} />,
+		)
+
+		const hexInput = component.getByTestId(
+			"mf-color-generator-hex-color-input-input",
+		)
+		const rgbInput = component.getByTestId(
+			"mf-color-generator-rgb-color-input-input",
+		)
+		const hexCopyButton = component.getByTestId(
+			"mf-color-generator-copy-hex-button",
+		)
+		const rgbCopyButton = component.getByTestId(
+			"mf-color-generator-copy-rgb-button",
+		)
+
+		await hexCopyButton.click()
+
+		const hexClipboard = await page.evaluate("navigator.clipboard.readText()")
+		expect(hexClipboard).toContain(await hexInput.inputValue())
+
+		await rgbCopyButton.click()
+
+		const rgbClipboard = await page.evaluate("navigator.clipboard.readText()")
+		expect(rgbClipboard).toContain(await rgbInput.inputValue())
+	})
 })

--- a/micro-services/src/index.ts
+++ b/micro-services/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./ms-app-config/src"
 export * from "./ms-app-controller/src"
 export * from "./ms-browser-env/src"
+export * from "./ms-clipboard/src"
 export * from "./ms-color-generator/src"
 export * from "./ms-date/src"
 export * from "./ms-error-handler/src"


### PR DESCRIPTION
[![CI/CD](https://github.com/arkadiuszPasciak/windows98/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/arkadiuszPasciak/windows98/actions/workflows/ci-cd.yml)

### ❓ Type of change

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply. -->
<!-- Delete options that are not relevant. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] ✨ New feature (a non-breaking change that adds functionality)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

`@windows98/micro-frontends/mf-color-generator`:
1. Added an option to copy the HEX or RGB color on clicking the button.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] Have you followed coding standards and best practices for the project?
- [x] Have you tested your changes?
- [x] Have you successfully run all tests?
- [x] Have you performed a self-review of your own code?
- [x] Have you ensured that your changes do not introduce any new security vulnerabilities?
