### PR TITLE
feature/w98-0057: mf-webcam

### DIFF
--- a/core/toolkit/src/helpers/index.ts
+++ b/core/toolkit/src/helpers/index.ts
@@ -1,3 +1,4 @@
 export * from "./builder"
+export * from "./loading-state"
 export * from "./observer"
 export * from "./singleton-factory"

--- a/core/toolkit/src/helpers/loading-state/index.ts
+++ b/core/toolkit/src/helpers/loading-state/index.ts
@@ -1,0 +1,2 @@
+export * from "./loading-state.helper"
+export * from "./loading-state.type"

--- a/core/toolkit/src/helpers/loading-state/loading-state.helper.ts
+++ b/core/toolkit/src/helpers/loading-state/loading-state.helper.ts
@@ -1,0 +1,17 @@
+import { LoadingState } from "./loading-state.type"
+
+export class LoadingStateHelper {
+	private _state: LoadingState
+
+	constructor() {
+		this._state = LoadingState.IDLE
+	}
+
+	setLoadingState(state: LoadingState) {
+		this._state = state
+	}
+
+	getLoadingState(): LoadingState {
+		return this._state
+	}
+}

--- a/core/toolkit/src/helpers/loading-state/loading-state.test.ts
+++ b/core/toolkit/src/helpers/loading-state/loading-state.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { LoadingStateHelper } from "./loading-state.helper"
+import { LoadingState } from "./loading-state.type"
+
+describe("LoadingStateHelper", () => {
+	let helper: LoadingStateHelper
+
+	beforeEach(() => {
+		helper = new LoadingStateHelper()
+	})
+
+	it("should initialize with IDLE state", () => {
+		expect(helper.getLoadingState()).toBe(LoadingState.IDLE)
+	})
+
+	it("should set state to LOADING", () => {
+		helper.setLoadingState(LoadingState.LOADING)
+		expect(helper.getLoadingState()).toBe(LoadingState.LOADING)
+	})
+
+	it("should set state to SUCCESS", () => {
+		helper.setLoadingState(LoadingState.SUCCESS)
+		expect(helper.getLoadingState()).toBe(LoadingState.SUCCESS)
+	})
+
+	it("should set state to ERROR", () => {
+		helper.setLoadingState(LoadingState.ERROR)
+		expect(helper.getLoadingState()).toBe(LoadingState.ERROR)
+	})
+})

--- a/core/toolkit/src/helpers/loading-state/loading-state.type.ts
+++ b/core/toolkit/src/helpers/loading-state/loading-state.type.ts
@@ -1,0 +1,6 @@
+export enum LoadingState {
+	ERROR = "error",
+	IDLE = "idle",
+	LOADING = "loading",
+	SUCCESS = "success",
+}

--- a/docs/src/stories/workspaces/micro-frontends/components/mf-webcam.stories.tsx
+++ b/docs/src/stories/workspaces/micro-frontends/components/mf-webcam.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { MFWebcam } from "@windows98/micro-frontends"
+
+const meta: Meta<typeof MFWebcam> = {
+	argTypes: {
+		onCloseProgram: {
+			action: "closed",
+			control: false,
+		},
+	},
+	component: MFWebcam,
+	tags: ["autodocs"],
+	title: "Workspaces/Micro Frontends/Components/MFWebcam",
+}
+
+export default meta
+
+type Story = StoryObj<typeof MFWebcam>
+
+export const Main: Story = {
+	args: {
+		onCloseProgram: () => console.log("Webcam closed"),
+	},
+}

--- a/micro-frontends/src/index.ts
+++ b/micro-frontends/src/index.ts
@@ -18,3 +18,4 @@ export { ThemeManagerView as MFThemeManager } from "./mf-theme-manager/src/ui/vi
 export { MFTicTacToe } from "./mf-tic-tac-toe/src/ui/views/tic-tac-toe"
 export { MFTimer } from "./mf-timer/src/ui/views"
 export { TimezoneView as MFTimezone } from "./mf-timezone/src/ui/views/timezone.view"
+export { MFWebcam } from "./mf-webcam/src/ui/views"

--- a/micro-frontends/src/mf-webcam/src/domain/contracts/domain.contract.ts
+++ b/micro-frontends/src/mf-webcam/src/domain/contracts/domain.contract.ts
@@ -1,0 +1,7 @@
+import type { Maybe } from "@windows98/toolkit"
+
+export interface WebcamDomainContract {
+	mediaStream: Maybe<MediaStream>
+
+	generateMediaStream(): Promise<void>
+}

--- a/micro-frontends/src/mf-webcam/src/domain/contracts/domain.contract.ts
+++ b/micro-frontends/src/mf-webcam/src/domain/contracts/domain.contract.ts
@@ -1,6 +1,6 @@
-import type { Maybe } from "@windows98/toolkit"
+import type { LoadingStateHelper, Maybe } from "@windows98/toolkit"
 
-export interface WebcamDomainContract {
+export interface WebcamDomainContract extends LoadingStateHelper {
 	mediaStream: Maybe<MediaStream>
 
 	generateMediaStream(): Promise<void>

--- a/micro-frontends/src/mf-webcam/src/domain/contracts/index.ts
+++ b/micro-frontends/src/mf-webcam/src/domain/contracts/index.ts
@@ -1,0 +1,1 @@
+export * from "./domain.contract"

--- a/micro-frontends/src/mf-webcam/src/domain/domains/index.ts
+++ b/micro-frontends/src/mf-webcam/src/domain/domains/index.ts
@@ -1,0 +1,1 @@
+export * from "./webcam.domain"

--- a/micro-frontends/src/mf-webcam/src/domain/domains/webcam.domain.ts
+++ b/micro-frontends/src/mf-webcam/src/domain/domains/webcam.domain.ts
@@ -1,17 +1,25 @@
 import { MSMediaDevices } from "@windows98/micro-services"
-import type { Maybe } from "@windows98/toolkit"
-import { makeAutoObservable } from "mobx"
+import { LoadingStateHelper, type Maybe } from "@windows98/toolkit"
+import { makeObservable, observable } from "mobx"
 import type { WebcamDomainContract } from "../contracts"
 
-export class WebcamDomain implements WebcamDomainContract {
+export class WebcamDomain
+	extends LoadingStateHelper
+	implements WebcamDomainContract
+{
 	mediaStream: Maybe<MediaStream> = null
 
 	constructor() {
-		makeAutoObservable(this)
+		super()
+		makeObservable(this, {
+			mediaStream: observable,
+		})
 	}
 
 	async generateMediaStream(): Promise<void> {
-		this.mediaStream = await MSMediaDevices.requestCameraStream({ video: true })
+		this.mediaStream = await MSMediaDevices.requestCameraStream({
+			video: true,
+		})
 	}
 }
 

--- a/micro-frontends/src/mf-webcam/src/domain/domains/webcam.domain.ts
+++ b/micro-frontends/src/mf-webcam/src/domain/domains/webcam.domain.ts
@@ -1,0 +1,18 @@
+import { MSMediaDevices } from "@windows98/micro-services"
+import type { Maybe } from "@windows98/toolkit"
+import { makeAutoObservable } from "mobx"
+import type { WebcamDomainContract } from "../contracts"
+
+export class WebcamDomain implements WebcamDomainContract {
+	mediaStream: Maybe<MediaStream> = null
+
+	constructor() {
+		makeAutoObservable(this)
+	}
+
+	async generateMediaStream(): Promise<void> {
+		this.mediaStream = await MSMediaDevices.requestCameraStream({ video: true })
+	}
+}
+
+export const webcamDomain = new WebcamDomain()

--- a/micro-frontends/src/mf-webcam/src/domain/index.ts
+++ b/micro-frontends/src/mf-webcam/src/domain/index.ts
@@ -1,0 +1,2 @@
+export * from "./contracts"
+export * from "./domains"

--- a/micro-frontends/src/mf-webcam/src/ui/context/config.context.tsx
+++ b/micro-frontends/src/mf-webcam/src/ui/context/config.context.tsx
@@ -1,0 +1,20 @@
+import {
+	type FunctionComponent,
+	type PropsWithChildren,
+	createContext,
+} from "react"
+import type { ConfigProps } from "./config.type"
+
+export const ConfigContext = createContext<ConfigProps>({
+	onCloseProgram: () => {},
+})
+
+export const ConfigContextComponent: FunctionComponent<
+	PropsWithChildren<ConfigProps>
+> = ({ children, onCloseProgram }) => {
+	return (
+		<ConfigContext.Provider value={{ onCloseProgram }}>
+			{children}
+		</ConfigContext.Provider>
+	)
+}

--- a/micro-frontends/src/mf-webcam/src/ui/context/config.type.ts
+++ b/micro-frontends/src/mf-webcam/src/ui/context/config.type.ts
@@ -1,0 +1,3 @@
+export interface ConfigProps {
+	onCloseProgram: () => void
+}

--- a/micro-frontends/src/mf-webcam/src/ui/context/domain.context.tsx
+++ b/micro-frontends/src/mf-webcam/src/ui/context/domain.context.tsx
@@ -1,0 +1,18 @@
+import {
+	type FunctionComponent,
+	type PropsWithChildren,
+	createContext,
+} from "react"
+import { webcamDomain } from "../../domain/domains"
+
+export const DomainContext = createContext(webcamDomain)
+
+export const DomainContextComponent: FunctionComponent<PropsWithChildren> = ({
+	children,
+}) => {
+	return (
+		<DomainContext.Provider value={webcamDomain}>
+			{children}
+		</DomainContext.Provider>
+	)
+}

--- a/micro-frontends/src/mf-webcam/src/ui/context/index.ts
+++ b/micro-frontends/src/mf-webcam/src/ui/context/index.ts
@@ -1,0 +1,3 @@
+export { ConfigContext, ConfigContextComponent } from "./config.context"
+export { DomainContext, DomainContextComponent } from "./domain.context"
+export type { ConfigProps } from "./config.type"

--- a/micro-frontends/src/mf-webcam/src/ui/hooks/index.ts
+++ b/micro-frontends/src/mf-webcam/src/ui/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from "./use-config.hook"
+export * from "./use-webcam.hook"

--- a/micro-frontends/src/mf-webcam/src/ui/hooks/use-config.hook.ts
+++ b/micro-frontends/src/mf-webcam/src/ui/hooks/use-config.hook.ts
@@ -1,0 +1,8 @@
+import { useContext } from "react"
+import { ConfigContext } from "../context"
+
+export function useConfig() {
+	const config = useContext(ConfigContext)
+
+	return { config }
+}

--- a/micro-frontends/src/mf-webcam/src/ui/hooks/use-webcam.hook.ts
+++ b/micro-frontends/src/mf-webcam/src/ui/hooks/use-webcam.hook.ts
@@ -1,0 +1,8 @@
+import { useContext } from "react"
+import { DomainContext } from "../context"
+
+export function useWebcam() {
+	const domain = useContext(DomainContext)
+
+	return { domain }
+}

--- a/micro-frontends/src/mf-webcam/src/ui/index.ts
+++ b/micro-frontends/src/mf-webcam/src/ui/index.ts
@@ -1,0 +1,4 @@
+export * from "./context"
+export * from "./hooks"
+export * from "./modules"
+export * from "./views"

--- a/micro-frontends/src/mf-webcam/src/ui/modules/index.ts
+++ b/micro-frontends/src/mf-webcam/src/ui/modules/index.ts
@@ -1,0 +1,3 @@
+export * from "./video"
+export * from "./modal"
+export * from "./wrapper"

--- a/micro-frontends/src/mf-webcam/src/ui/modules/modal/index.ts
+++ b/micro-frontends/src/mf-webcam/src/ui/modules/modal/index.ts
@@ -1,0 +1,2 @@
+export { Modal } from "./modal"
+export type { ModalProps } from "./modal.type"

--- a/micro-frontends/src/mf-webcam/src/ui/modules/modal/modal.tsx
+++ b/micro-frontends/src/mf-webcam/src/ui/modules/modal/modal.tsx
@@ -1,0 +1,21 @@
+import { DSModal } from "@windows98/design-system"
+import type { FunctionComponent } from "react"
+import type { ModalProps } from "./modal.type"
+import { useModal } from "./use-modal.hook"
+
+export const Modal: FunctionComponent<ModalProps> = ({ children }) => {
+	const { translations, onCloseProgram } = useModal()
+
+	return (
+		<DSModal
+			id="mf-webcam"
+			moveWindow={true}
+			onClose={onCloseProgram}
+			title={translations.title}
+			width="500px"
+			height="425px"
+		>
+			{children}
+		</DSModal>
+	)
+}

--- a/micro-frontends/src/mf-webcam/src/ui/modules/modal/modal.type.ts
+++ b/micro-frontends/src/mf-webcam/src/ui/modules/modal/modal.type.ts
@@ -1,0 +1,3 @@
+import type { PropsWithChildren } from "react"
+
+export interface ModalProps extends PropsWithChildren {}

--- a/micro-frontends/src/mf-webcam/src/ui/modules/modal/use-modal.hook.ts
+++ b/micro-frontends/src/mf-webcam/src/ui/modules/modal/use-modal.hook.ts
@@ -1,0 +1,16 @@
+import { useTranslation } from "react-i18next"
+import { useConfig } from "../../hooks"
+
+export const useModal = () => {
+	const { t } = useTranslation()
+	const { config } = useConfig()
+
+	const translations = {
+		title: t("mf-webcam.title"),
+	}
+
+	return {
+		translations,
+		onCloseProgram: config.onCloseProgram,
+	}
+}

--- a/micro-frontends/src/mf-webcam/src/ui/modules/video/index.ts
+++ b/micro-frontends/src/mf-webcam/src/ui/modules/video/index.ts
@@ -1,0 +1,1 @@
+export * from "./video"

--- a/micro-frontends/src/mf-webcam/src/ui/modules/video/use-video.hook.ts
+++ b/micro-frontends/src/mf-webcam/src/ui/modules/video/use-video.hook.ts
@@ -1,3 +1,4 @@
+import { LoadingState } from "@windows98/toolkit"
 import { useEffect, useRef } from "react"
 import { useWebcam } from "../../hooks"
 
@@ -6,10 +7,16 @@ export function useVideo() {
 	const videoRef = useRef<HTMLVideoElement>(null)
 
 	const setupMediaStream = async () => {
-		await domain.generateMediaStream()
+		try {
+			domain.setLoadingState(LoadingState.LOADING)
+			await domain.generateMediaStream()
 
-		if (videoRef.current) {
-			videoRef.current.srcObject = domain.mediaStream
+			if (videoRef.current && domain.mediaStream) {
+				videoRef.current.srcObject = domain.mediaStream
+				domain.setLoadingState(LoadingState.SUCCESS)
+			}
+		} catch {
+			domain.setLoadingState(LoadingState.ERROR)
 		}
 	}
 

--- a/micro-frontends/src/mf-webcam/src/ui/modules/video/use-video.hook.ts
+++ b/micro-frontends/src/mf-webcam/src/ui/modules/video/use-video.hook.ts
@@ -1,0 +1,24 @@
+import { useEffect, useRef } from "react"
+import { useWebcam } from "../../hooks"
+
+export function useVideo() {
+	const { domain } = useWebcam()
+	const videoRef = useRef<HTMLVideoElement>(null)
+
+	const setupMediaStream = async () => {
+		await domain.generateMediaStream()
+
+		if (videoRef.current) {
+			videoRef.current.srcObject = domain.mediaStream
+		}
+	}
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: render only once
+	useEffect(() => {
+		setupMediaStream()
+	}, [])
+
+	return {
+		videoRef,
+	}
+}

--- a/micro-frontends/src/mf-webcam/src/ui/modules/video/video.module.css
+++ b/micro-frontends/src/mf-webcam/src/ui/modules/video/video.module.css
@@ -1,0 +1,5 @@
+.video {
+	padding: var(--ds-spacing-xs);
+	box-shadow: var(--ds-border-field);
+	object-fit: cover;
+}

--- a/micro-frontends/src/mf-webcam/src/ui/modules/video/video.tsx
+++ b/micro-frontends/src/mf-webcam/src/ui/modules/video/video.tsx
@@ -1,0 +1,20 @@
+import { observer } from "mobx-react-lite"
+import type { FunctionComponent } from "react"
+import { useVideo } from "./use-video.hook"
+import styles from "./video.module.css"
+
+export const Video: FunctionComponent = observer(() => {
+	const { videoRef } = useVideo()
+
+	return (
+		// biome-ignore lint/a11y/useMediaCaption: It's a test of the webcam
+		<video
+			className={styles.video}
+			data-testid="mf-webcam-video"
+			autoPlay
+			height="100%"
+			ref={videoRef}
+			width="100%"
+		/>
+	)
+})

--- a/micro-frontends/src/mf-webcam/src/ui/modules/wrapper/index.ts
+++ b/micro-frontends/src/mf-webcam/src/ui/modules/wrapper/index.ts
@@ -1,0 +1,1 @@
+export { Wrapper } from "./wrapper"

--- a/micro-frontends/src/mf-webcam/src/ui/modules/wrapper/wrapper.tsx
+++ b/micro-frontends/src/mf-webcam/src/ui/modules/wrapper/wrapper.tsx
@@ -1,0 +1,10 @@
+import { Modal } from "../modal"
+import { Video } from "../video"
+
+export const Wrapper = () => {
+	return (
+		<Modal>
+			<Video />
+		</Modal>
+	)
+}

--- a/micro-frontends/src/mf-webcam/src/ui/views/index.ts
+++ b/micro-frontends/src/mf-webcam/src/ui/views/index.ts
@@ -1,0 +1,1 @@
+export * from "./webcam"

--- a/micro-frontends/src/mf-webcam/src/ui/views/webcam/index.ts
+++ b/micro-frontends/src/mf-webcam/src/ui/views/webcam/index.ts
@@ -1,0 +1,2 @@
+export { MFWebcam } from "./webcam.view"
+export type { WebcamViewProps } from "./webcam.type"

--- a/micro-frontends/src/mf-webcam/src/ui/views/webcam/webcam.type.ts
+++ b/micro-frontends/src/mf-webcam/src/ui/views/webcam/webcam.type.ts
@@ -1,0 +1,3 @@
+import type { ConfigProps } from "../../context"
+
+export interface WebcamViewProps extends ConfigProps {}

--- a/micro-frontends/src/mf-webcam/src/ui/views/webcam/webcam.view.tsx
+++ b/micro-frontends/src/mf-webcam/src/ui/views/webcam/webcam.view.tsx
@@ -1,0 +1,16 @@
+import type { FunctionComponent } from "react"
+import { ConfigContextComponent, DomainContextComponent } from "../../context"
+import { Wrapper } from "../../modules/wrapper"
+import type { WebcamViewProps } from "./webcam.type"
+
+export const MFWebcam: FunctionComponent<WebcamViewProps> = ({
+	onCloseProgram,
+}) => {
+	return (
+		<ConfigContextComponent onCloseProgram={onCloseProgram}>
+			<DomainContextComponent>
+				<Wrapper />
+			</DomainContextComponent>
+		</ConfigContextComponent>
+	)
+}

--- a/micro-frontends/src/mf-webcam/tests/domain/webcam.test.ts
+++ b/micro-frontends/src/mf-webcam/tests/domain/webcam.test.ts
@@ -1,0 +1,25 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { WebcamDomain } from "../../src/domain/domains/webcam.domain"
+
+vi.mock("@windows98/micro-services", () => ({
+	MSMediaDevices: {
+		requestCameraStream: vi.fn(() => Promise.resolve("mock-stream")),
+	},
+}))
+
+describe("WebcamDomain", () => {
+	let domain: WebcamDomain
+
+	beforeEach(() => {
+		domain = new WebcamDomain()
+	})
+
+	it("should initialize with null mediaStream", () => {
+		expect(domain.mediaStream).toBeNull()
+	})
+
+	it("should set mediaStream after generateMediaStream", async () => {
+		await domain.generateMediaStream()
+		expect(domain.mediaStream).toBe("mock-stream")
+	})
+})

--- a/micro-frontends/src/mf-webcam/tests/ui/webcam.test.tsx
+++ b/micro-frontends/src/mf-webcam/tests/ui/webcam.test.tsx
@@ -1,0 +1,13 @@
+import { expect, test } from "@playwright/experimental-ct-react"
+import { MFWebcam } from "../../src/ui/views"
+
+test.describe("MFWebcam", () => {
+	test("renders webcam video element", async ({ mount }) => {
+		const component = await mount(<MFWebcam onCloseProgram={() => {}} />)
+
+		const video = component.getByTestId("mf-webcam-video")
+		await expect(video).toBeVisible()
+
+		await expect(video).toHaveAttribute("autoplay", "")
+	})
+})


### PR DESCRIPTION
[![CI/CD](https://github.com/arkadiuszPasciak/windows98/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/arkadiuszPasciak/windows98/actions/workflows/ci-cd.yml)

### ❓ Type of change

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply. -->
<!-- Delete options that are not relevant. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] ✨ New feature (a non-breaking change that adds functionality)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

This PR implements a new webcam micro-frontend component for the Windows 98 application, providing live camera stream functionality within a modal interface. The implementation follows the established architecture patterns with proper domain separation, context management, and testing coverage.

- Adds MFWebcam component with video streaming capabilities and modal UI
- Implements webcam domain logic with loading state management
- Introduces LoadingStateHelper utility class for state tracking across the toolkit

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] Have you followed coding standards and best practices for the project?
- [x] Have you tested your changes?
- [x] Have you successfully run all tests?
- [x] Have you performed a self-review of your own code?
- [x] Have you ensured that your changes do not introduce any new security vulnerabilities?
