### PR TITLE
chore/w98-0127: update vite ecosystem 2

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -41,7 +41,7 @@
 		"lint-staged": "16.4.0",
 		"stylelint": "17.6.0",
 		"typescript": "5.9.3",
-		"vite": "8.0.3"
+		"vite": "8.0.6"
 	},
 	"type": "module"
 }

--- a/core/configs/package.json
+++ b/core/configs/package.json
@@ -29,7 +29,7 @@
 		"lint-staged": "16.4.0",
 		"stylelint": "17.6.0",
 		"typescript": "5.9.3",
-		"vitest": "4.1.2"
+		"vitest": "4.1.3"
 	},
 	"scripts": {
 		"lint:code:fix": "biome check --config-path ./@linter/biome.config.json --fix",

--- a/core/configs/src/pnpm/read-package.hook.cjs
+++ b/core/configs/src/pnpm/read-package.hook.cjs
@@ -20,7 +20,7 @@ class PNPMReadPackageHook {
 			stylelint: "17.6.0",
 			storybook: "10.3.4",
 			typescript: "5.9.3",
-			vite: "8.0.3",
+			vite: "8.0.6",
 			"vite-plugin-css-injected-by-js": "4.0.1",
 			"vite-plugin-dts": "4.5.4",
 			vitest: "4.1.2",

--- a/core/configs/src/pnpm/read-package.hook.cjs
+++ b/core/configs/src/pnpm/read-package.hook.cjs
@@ -23,7 +23,7 @@ class PNPMReadPackageHook {
 			vite: "8.0.6",
 			"vite-plugin-css-injected-by-js": "4.0.1",
 			"vite-plugin-dts": "4.5.4",
-			vitest: "4.1.2",
+			vitest: "4.1.3",
 		},
 		types: [
 			"dependencies",

--- a/core/configs/src/pnpm/read-package.hook.cjs
+++ b/core/configs/src/pnpm/read-package.hook.cjs
@@ -10,7 +10,7 @@ class PNPMReadPackageHook {
 			"@types/react": "19.2.10",
 			"@types/react-dom": "19.2.3",
 			i18next: "26.0.3",
-			lightningcss: "1.31.1",
+			lightningcss: "1.32.0",
 			"lint-staged": "16.4.0",
 			mobx: "6.15.0",
 			"mobx-react-lite": "4.1.1",

--- a/core/design-system/package.json
+++ b/core/design-system/package.json
@@ -50,7 +50,7 @@
 		"@vitejs/plugin-react": "6.0.1",
 		"@windows98/configs": "workspace:*",
 		"@windows98/toolkit": "workspace:*",
-		"lightningcss": "1.31.1",
+		"lightningcss": "1.32.0",
 		"lint-staged": "16.4.0",
 		"stylelint": "17.6.0",
 		"typescript": "5.9.3",

--- a/core/design-system/package.json
+++ b/core/design-system/package.json
@@ -54,7 +54,7 @@
 		"lint-staged": "16.4.0",
 		"stylelint": "17.6.0",
 		"typescript": "5.9.3",
-		"vite": "8.0.3",
+		"vite": "8.0.6",
 		"vite-plugin-css-injected-by-js": "4.0.1",
 		"vite-plugin-dts": "4.5.4",
 		"vitest": "4.1.2"

--- a/core/design-system/package.json
+++ b/core/design-system/package.json
@@ -57,6 +57,6 @@
 		"vite": "8.0.6",
 		"vite-plugin-css-injected-by-js": "4.0.1",
 		"vite-plugin-dts": "4.5.4",
-		"vitest": "4.1.2"
+		"vitest": "4.1.3"
 	}
 }

--- a/core/toolkit/package.json
+++ b/core/toolkit/package.json
@@ -17,7 +17,7 @@
 		"@windows98/web": "workspace:*",
 		"lint-staged": "16.4.0",
 		"typescript": "5.9.3",
-		"vitest": "4.1.2"
+		"vitest": "4.1.3"
 	},
 	"scripts": {
 		"lint:code:fix": "biome check --config-path ./@linter/biome.config.json --fix",

--- a/core/web/package.json
+++ b/core/web/package.json
@@ -31,7 +31,7 @@
 		"typescript": "5.9.3",
 		"vite": "8.0.6",
 		"vite-plugin-dts": "4.5.4",
-		"vitest": "4.1.2"
+		"vitest": "4.1.3"
 	},
 	"scripts": {
 		"dev": "vite @bundler",

--- a/core/web/package.json
+++ b/core/web/package.json
@@ -29,7 +29,7 @@
 		"@windows98/toolkit": "workspace:*",
 		"lint-staged": "16.4.0",
 		"typescript": "5.9.3",
-		"vite": "8.0.3",
+		"vite": "8.0.6",
 		"vite-plugin-dts": "4.5.4",
 		"vitest": "4.1.2"
 	},

--- a/docs/package.json
+++ b/docs/package.json
@@ -20,7 +20,7 @@
 		"lint-staged": "16.4.0",
 		"storybook": "10.3.4",
 		"typescript": "5.9.3",
-		"vite": "8.0.3"
+		"vite": "8.0.6"
 	},
 	"main": ".storybook/main.ts",
 	"name": "@windows98/docs",

--- a/micro-frontends/package.json
+++ b/micro-frontends/package.json
@@ -34,7 +34,7 @@
 		"lint-staged": "16.4.0",
 		"stylelint": "17.6.0",
 		"typescript": "5.9.3",
-		"vite": "8.0.3",
+		"vite": "8.0.6",
 		"vite-plugin-css-injected-by-js": "4.0.1",
 		"vite-plugin-dts": "4.5.4",
 		"vitest": "4.1.2"

--- a/micro-frontends/package.json
+++ b/micro-frontends/package.json
@@ -37,7 +37,7 @@
 		"vite": "8.0.6",
 		"vite-plugin-css-injected-by-js": "4.0.1",
 		"vite-plugin-dts": "4.5.4",
-		"vitest": "4.1.2"
+		"vitest": "4.1.3"
 	},
 	"engines": {
 		"node": "24.14.1",

--- a/micro-services/package.json
+++ b/micro-services/package.json
@@ -26,7 +26,7 @@
 		"@windows98/toolkit": "workspace:*",
 		"lint-staged": "16.4.0",
 		"typescript": "5.9.3",
-		"vite": "8.0.3",
+		"vite": "8.0.6",
 		"vite-plugin-dts": "4.5.4",
 		"vitest": "4.1.2"
 	},

--- a/micro-services/package.json
+++ b/micro-services/package.json
@@ -28,7 +28,7 @@
 		"typescript": "5.9.3",
 		"vite": "8.0.6",
 		"vite-plugin-dts": "4.5.4",
-		"vitest": "4.1.2"
+		"vitest": "4.1.3"
 	},
 	"scripts": {
 		"dev": "vite @bundler",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,7 +128,7 @@ importers:
         version: 2.4.10
       '@playwright/experimental-ct-react':
         specifier: 1.59.1
-        version: 1.59.1(@types/node@22.13.14)(lightningcss@1.31.1)(sass@1.83.0)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))(yaml@2.8.3)
+        version: 1.59.1(@types/node@22.13.14)(lightningcss@1.32.0)(sass@1.83.0)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))(yaml@2.8.3)
       '@types/node':
         specifier: 22.13.14
         version: 22.13.14
@@ -148,8 +148,8 @@ importers:
         specifier: workspace:*
         version: link:../toolkit
       lightningcss:
-        specifier: 1.31.1
-        version: 1.31.1
+        specifier: 1.32.0
+        version: 1.32.0
       lint-staged:
         specifier: 16.4.0
         version: 16.4.0
@@ -2376,34 +2376,16 @@ packages:
   kolorist@1.8.0:
     resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
 
-  lightningcss-android-arm64@1.31.1:
-    resolution: {integrity: sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [android]
-
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [android]
 
-  lightningcss-darwin-arm64@1.31.1:
-    resolution: {integrity: sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [darwin]
-
   lightningcss-darwin-arm64@1.32.0:
     resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
-    os: [darwin]
-
-  lightningcss-darwin-x64@1.31.1:
-    resolution: {integrity: sha512-1ObhyoCY+tGxtsz1lSx5NXCj3nirk0Y0kB/g8B8DT+sSx4G9djitg9ejFnjb3gJNWo7qXH4DIy2SUHvpoFwfTA==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
     os: [darwin]
 
   lightningcss-darwin-x64@1.32.0:
@@ -2412,36 +2394,17 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  lightningcss-freebsd-x64@1.31.1:
-    resolution: {integrity: sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [freebsd]
-
   lightningcss-freebsd-x64@1.32.0:
     resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
 
-  lightningcss-linux-arm-gnueabihf@1.31.1:
-    resolution: {integrity: sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm]
-    os: [linux]
-
   lightningcss-linux-arm-gnueabihf@1.32.0:
     resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm]
     os: [linux]
-
-  lightningcss-linux-arm64-gnu@1.31.1:
-    resolution: {integrity: sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.32.0:
     resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
@@ -2450,26 +2413,12 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  lightningcss-linux-arm64-musl@1.31.1:
-    resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
-
-  lightningcss-linux-x64-gnu@1.31.1:
-    resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
@@ -2478,13 +2427,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  lightningcss-linux-x64-musl@1.31.1:
-    resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
@@ -2492,22 +2434,10 @@ packages:
     os: [linux]
     libc: [musl]
 
-  lightningcss-win32-arm64-msvc@1.31.1:
-    resolution: {integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [win32]
-
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
-    os: [win32]
-
-  lightningcss-win32-x64-msvc@1.31.1:
-    resolution: {integrity: sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
     os: [win32]
 
   lightningcss-win32-x64-msvc@1.32.0:
@@ -2515,10 +2445,6 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [win32]
-
-  lightningcss@1.31.1:
-    resolution: {integrity: sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==}
-    engines: {node: '>= 12.0.0'}
 
   lightningcss@1.32.0:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
@@ -4005,24 +3931,6 @@ snapshots:
       '@parcel/watcher-win32-x64': 2.5.1
     optional: true
 
-  '@playwright/experimental-ct-core@1.59.1(@types/node@22.13.14)(lightningcss@1.31.1)(sass@1.83.0)(yaml@2.8.3)':
-    dependencies:
-      playwright: 1.59.1
-      playwright-core: 1.59.1
-      vite: 6.4.1(@types/node@22.13.14)(lightningcss@1.31.1)(sass@1.83.0)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
-
   '@playwright/experimental-ct-core@1.59.1(@types/node@22.13.14)(lightningcss@1.32.0)(sass@1.83.0)(yaml@2.8.3)':
     dependencies:
       playwright: 1.59.1
@@ -4039,25 +3947,6 @@ snapshots:
       - sugarss
       - terser
       - tsx
-      - yaml
-
-  '@playwright/experimental-ct-react@1.59.1(@types/node@22.13.14)(lightningcss@1.31.1)(sass@1.83.0)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))(yaml@2.8.3)':
-    dependencies:
-      '@playwright/experimental-ct-core': 1.59.1(@types/node@22.13.14)(lightningcss@1.31.1)(sass@1.83.0)(yaml@2.8.3)
-      '@vitejs/plugin-react': 4.7.0(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - vite
       - yaml
 
   '@playwright/experimental-ct-react@1.59.1(@types/node@22.13.14)(lightningcss@1.32.0)(sass@1.83.0)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))(yaml@2.8.3)':
@@ -5263,87 +5152,38 @@ snapshots:
 
   kolorist@1.8.0: {}
 
-  lightningcss-android-arm64@1.31.1:
-    optional: true
-
   lightningcss-android-arm64@1.32.0:
-    optional: true
-
-  lightningcss-darwin-arm64@1.31.1:
     optional: true
 
   lightningcss-darwin-arm64@1.32.0:
     optional: true
 
-  lightningcss-darwin-x64@1.31.1:
-    optional: true
-
   lightningcss-darwin-x64@1.32.0:
-    optional: true
-
-  lightningcss-freebsd-x64@1.31.1:
     optional: true
 
   lightningcss-freebsd-x64@1.32.0:
     optional: true
 
-  lightningcss-linux-arm-gnueabihf@1.31.1:
-    optional: true
-
   lightningcss-linux-arm-gnueabihf@1.32.0:
-    optional: true
-
-  lightningcss-linux-arm64-gnu@1.31.1:
     optional: true
 
   lightningcss-linux-arm64-gnu@1.32.0:
     optional: true
 
-  lightningcss-linux-arm64-musl@1.31.1:
-    optional: true
-
   lightningcss-linux-arm64-musl@1.32.0:
-    optional: true
-
-  lightningcss-linux-x64-gnu@1.31.1:
     optional: true
 
   lightningcss-linux-x64-gnu@1.32.0:
     optional: true
 
-  lightningcss-linux-x64-musl@1.31.1:
-    optional: true
-
   lightningcss-linux-x64-musl@1.32.0:
-    optional: true
-
-  lightningcss-win32-arm64-msvc@1.31.1:
     optional: true
 
   lightningcss-win32-arm64-msvc@1.32.0:
     optional: true
 
-  lightningcss-win32-x64-msvc@1.31.1:
-    optional: true
-
   lightningcss-win32-x64-msvc@1.32.0:
     optional: true
-
-  lightningcss@1.31.1:
-    dependencies:
-      detect-libc: 2.0.4
-    optionalDependencies:
-      lightningcss-android-arm64: 1.31.1
-      lightningcss-darwin-arm64: 1.31.1
-      lightningcss-darwin-x64: 1.31.1
-      lightningcss-freebsd-x64: 1.31.1
-      lightningcss-linux-arm-gnueabihf: 1.31.1
-      lightningcss-linux-arm64-gnu: 1.31.1
-      lightningcss-linux-arm64-musl: 1.31.1
-      lightningcss-linux-x64-gnu: 1.31.1
-      lightningcss-linux-x64-musl: 1.31.1
-      lightningcss-win32-arm64-msvc: 1.31.1
-      lightningcss-win32-x64-msvc: 1.31.1
 
   lightningcss@1.32.0:
     dependencies:
@@ -6072,21 +5912,6 @@ snapshots:
       - '@types/node'
       - rollup
       - supports-color
-
-  vite@6.4.1(@types/node@22.13.14)(lightningcss@1.31.1)(sass@1.83.0)(yaml@2.8.3):
-    dependencies:
-      esbuild: 0.25.3
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.8
-      rollup: 4.50.2
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 22.13.14
-      fsevents: 2.3.3
-      lightningcss: 1.31.1
-      sass: 1.83.0
-      yaml: 2.8.3
 
   vite@6.4.1(@types/node@22.13.14)(lightningcss@1.32.0)(sass@1.83.0)(yaml@2.8.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,8 +101,8 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       vitest:
-        specifier: 4.1.2
-        version: 4.1.2(@types/node@22.13.14)(jsdom@25.0.1)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
+        specifier: 4.1.3
+        version: 4.1.3(@types/node@22.13.14)(jsdom@25.0.1)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
     devDependencies:
       '@types/react':
         specifier: 19.2.10
@@ -169,8 +169,8 @@ importers:
         specifier: 4.5.4
         version: 4.5.4(@types/node@22.13.14)(rollup@4.50.2)(typescript@5.9.3)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
       vitest:
-        specifier: 4.1.2
-        version: 4.1.2(@types/node@22.13.14)(jsdom@25.0.1)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
+        specifier: 4.1.3
+        version: 4.1.3(@types/node@22.13.14)(jsdom@25.0.1)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
 
   core/internationalization/i18n:
     devDependencies:
@@ -211,8 +211,8 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       vitest:
-        specifier: 4.1.2
-        version: 4.1.2(@types/node@22.13.14)(jsdom@25.0.1)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
+        specifier: 4.1.3
+        version: 4.1.3(@types/node@22.13.14)(jsdom@25.0.1)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
 
   core/web:
     devDependencies:
@@ -238,8 +238,8 @@ importers:
         specifier: 4.5.4
         version: 4.5.4(@types/node@22.13.14)(rollup@4.50.2)(typescript@5.9.3)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
       vitest:
-        specifier: 4.1.2
-        version: 4.1.2(@types/node@22.13.14)(jsdom@25.0.1)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
+        specifier: 4.1.3
+        version: 4.1.3(@types/node@22.13.14)(jsdom@25.0.1)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
 
   docs:
     dependencies:
@@ -366,8 +366,8 @@ importers:
         specifier: 4.5.4
         version: 4.5.4(@types/node@22.13.14)(rollup@4.50.2)(typescript@5.9.3)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
       vitest:
-        specifier: 4.1.2
-        version: 4.1.2(@types/node@22.13.14)(jsdom@25.0.1)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
+        specifier: 4.1.3
+        version: 4.1.3(@types/node@22.13.14)(jsdom@25.0.1)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
 
   micro-services:
     dependencies:
@@ -400,8 +400,8 @@ importers:
         specifier: 4.5.4
         version: 4.5.4(@types/node@22.13.14)(rollup@4.50.2)(typescript@5.9.3)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
       vitest:
-        specifier: 4.1.2
-        version: 4.1.2(@types/node@22.13.14)(jsdom@25.0.1)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
+        specifier: 4.1.3
+        version: 4.1.3(@types/node@22.13.14)(jsdom@25.0.1)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
 
 packages:
 
@@ -1579,11 +1579,11 @@ packages:
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
-  '@vitest/expect@4.1.2':
-    resolution: {integrity: sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==}
+  '@vitest/expect@4.1.3':
+    resolution: {integrity: sha512-CW8Q9KMtXDGHj0vCsqui0M5KqRsu0zm0GNDW7Gd3U7nZ2RFpPKSCpeCXoT+/+5zr1TNlsoQRDEz+LzZUyq6gnQ==}
 
-  '@vitest/mocker@4.1.2':
-    resolution: {integrity: sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==}
+  '@vitest/mocker@4.1.3':
+    resolution: {integrity: sha512-XN3TrycitDQSzGRnec/YWgoofkYRhouyVQj4YNsJ5r/STCUFqMrP4+oxEv3e7ZbLi4og5kIHrZwekDJgw6hcjw==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -1596,26 +1596,26 @@ packages:
   '@vitest/pretty-format@3.2.4':
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
 
-  '@vitest/pretty-format@4.1.2':
-    resolution: {integrity: sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==}
+  '@vitest/pretty-format@4.1.3':
+    resolution: {integrity: sha512-hYqqwuMbpkkBodpRh4k4cQSOELxXky1NfMmQvOfKvV8zQHz8x8Dla+2wzElkMkBvSAJX5TRGHJAQvK0TcOafwg==}
 
-  '@vitest/runner@4.1.2':
-    resolution: {integrity: sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==}
+  '@vitest/runner@4.1.3':
+    resolution: {integrity: sha512-VwgOz5MmT0KhlUj40h02LWDpUBVpflZ/b7xZFA25F29AJzIrE+SMuwzFf0b7t4EXdwRNX61C3B6auIXQTR3ttA==}
 
-  '@vitest/snapshot@4.1.2':
-    resolution: {integrity: sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==}
+  '@vitest/snapshot@4.1.3':
+    resolution: {integrity: sha512-9l+k/J9KG5wPJDX9BcFFzhhwNjwkRb8RsnYhaT1vPY7OufxmQFc9sZzScRCPTiETzl37mrIWVY9zxzmdVeJwDQ==}
 
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
 
-  '@vitest/spy@4.1.2':
-    resolution: {integrity: sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==}
+  '@vitest/spy@4.1.3':
+    resolution: {integrity: sha512-ujj5Uwxagg4XUIfAUyRQxAg631BP6e9joRiN99mr48Bg9fRs+5mdUElhOoZ6rP5mBr8Bs3lmrREnkrQWkrsTCw==}
 
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
-  '@vitest/utils@4.1.2':
-    resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
+  '@vitest/utils@4.1.3':
+    resolution: {integrity: sha512-Pc/Oexse/khOWsGB+w3q4yzA4te7W4gpZZAvk+fr8qXfTURZUMj5i7kuxsNK5mP/dEB6ao3jfr0rs17fHhbHdw==}
 
   '@volar/language-core@2.4.11':
     resolution: {integrity: sha512-lN2C1+ByfW9/JRPpqScuZt/4OrUUse57GLI6TbLgTIqBVemdl1wNcZ1qYGEo2+Gw8coYLgCy7SuKqn6IrQcQgg==}
@@ -3266,18 +3266,20 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.2:
-    resolution: {integrity: sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==}
+  vitest@4.1.3:
+    resolution: {integrity: sha512-DBc4Tx0MPNsqb9isoyOq00lHftVx/KIU44QOm2q59npZyLUkENn8TMFsuzuO+4U2FUa9rgbbPt3udrP25GcjXw==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.2
-      '@vitest/browser-preview': 4.1.2
-      '@vitest/browser-webdriverio': 4.1.2
-      '@vitest/ui': 4.1.2
+      '@vitest/browser-playwright': 4.1.3
+      '@vitest/browser-preview': 4.1.3
+      '@vitest/browser-webdriverio': 4.1.3
+      '@vitest/coverage-istanbul': 4.1.3
+      '@vitest/coverage-v8': 4.1.3
+      '@vitest/ui': 4.1.3
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -3293,6 +3295,10 @@ packages:
       '@vitest/browser-preview':
         optional: true
       '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
         optional: true
       '@vitest/ui':
         optional: true
@@ -4440,18 +4446,18 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/expect@4.1.2':
+  '@vitest/expect@4.1.3':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.2
-      '@vitest/spy': 4.1.2
-      '@vitest/utils': 4.1.2
+      '@vitest/spy': 4.1.3
+      '@vitest/utils': 4.1.3
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.2(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.3(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))':
     dependencies:
-      '@vitest/spy': 4.1.2
+      '@vitest/spy': 4.1.3
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
@@ -4461,19 +4467,19 @@ snapshots:
     dependencies:
       tinyrainbow: 2.0.0
 
-  '@vitest/pretty-format@4.1.2':
+  '@vitest/pretty-format@4.1.3':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.2':
+  '@vitest/runner@4.1.3':
     dependencies:
-      '@vitest/utils': 4.1.2
+      '@vitest/utils': 4.1.3
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.2':
+  '@vitest/snapshot@4.1.3':
     dependencies:
-      '@vitest/pretty-format': 4.1.2
-      '@vitest/utils': 4.1.2
+      '@vitest/pretty-format': 4.1.3
+      '@vitest/utils': 4.1.3
       magic-string: 0.30.21
       pathe: 2.0.3
 
@@ -4481,7 +4487,7 @@ snapshots:
     dependencies:
       tinyspy: 4.0.3
 
-  '@vitest/spy@4.1.2': {}
+  '@vitest/spy@4.1.3': {}
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -4489,9 +4495,9 @@ snapshots:
       loupe: 3.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/utils@4.1.2':
+  '@vitest/utils@4.1.3':
     dependencies:
-      '@vitest/pretty-format': 4.1.2
+      '@vitest/pretty-format': 4.1.3
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -6111,21 +6117,21 @@ snapshots:
       sass: 1.83.0
       yaml: 2.8.3
 
-  vitest@4.1.2(@types/node@22.13.14)(jsdom@25.0.1)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)):
+  vitest@4.1.3(@types/node@22.13.14)(jsdom@25.0.1)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)):
     dependencies:
-      '@vitest/expect': 4.1.2
-      '@vitest/mocker': 4.1.2(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
-      '@vitest/pretty-format': 4.1.2
-      '@vitest/runner': 4.1.2
-      '@vitest/snapshot': 4.1.2
-      '@vitest/spy': 4.1.2
-      '@vitest/utils': 4.1.2
+      '@vitest/expect': 4.1.3
+      '@vitest/mocker': 4.1.3(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.3
+      '@vitest/runner': 4.1.3
+      '@vitest/snapshot': 4.1.3
+      '@vitest/spy': 4.1.3
+      '@vitest/utils': 4.1.3
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,7 +64,7 @@ importers:
         version: 19.2.3(@types/react@19.2.10)
       '@vitejs/plugin-react':
         specifier: 6.0.1
-        version: 6.0.1(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
+        version: 6.0.1(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
       '@windows98/toolkit':
         specifier: workspace:*
         version: link:../core/toolkit
@@ -78,8 +78,8 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       vite:
-        specifier: 8.0.3
-        version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)
+        specifier: 8.0.6
+        version: 8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)
 
   core/ci-cd: {}
 
@@ -90,7 +90,7 @@ importers:
         version: 2.4.10
       '@playwright/experimental-ct-react':
         specifier: 1.59.1
-        version: 1.59.1(@types/node@22.13.14)(lightningcss@1.32.0)(sass@1.83.0)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))(yaml@2.8.3)
+        version: 1.59.1(@types/node@22.13.14)(lightningcss@1.32.0)(sass@1.83.0)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))(yaml@2.8.3)
       lint-staged:
         specifier: 16.4.0
         version: 16.4.0
@@ -102,7 +102,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 4.1.2
-        version: 4.1.2(@types/node@22.13.14)(jsdom@25.0.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
+        version: 4.1.2(@types/node@22.13.14)(jsdom@25.0.1)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
     devDependencies:
       '@types/react':
         specifier: 19.2.10
@@ -128,7 +128,7 @@ importers:
         version: 2.4.10
       '@playwright/experimental-ct-react':
         specifier: 1.59.1
-        version: 1.59.1(@types/node@22.13.14)(lightningcss@1.31.1)(sass@1.83.0)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))(yaml@2.8.3)
+        version: 1.59.1(@types/node@22.13.14)(lightningcss@1.31.1)(sass@1.83.0)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))(yaml@2.8.3)
       '@types/node':
         specifier: 22.13.14
         version: 22.13.14
@@ -140,7 +140,7 @@ importers:
         version: 19.2.3(@types/react@19.2.10)
       '@vitejs/plugin-react':
         specifier: 6.0.1
-        version: 6.0.1(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
+        version: 6.0.1(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
       '@windows98/configs':
         specifier: workspace:*
         version: link:../configs
@@ -160,17 +160,17 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       vite:
-        specifier: 8.0.3
-        version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)
+        specifier: 8.0.6
+        version: 8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)
       vite-plugin-css-injected-by-js:
         specifier: 4.0.1
-        version: 4.0.1(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
+        version: 4.0.1(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@22.13.14)(rollup@4.50.2)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
+        version: 4.5.4(@types/node@22.13.14)(rollup@4.50.2)(typescript@5.9.3)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
       vitest:
         specifier: 4.1.2
-        version: 4.1.2(@types/node@22.13.14)(jsdom@25.0.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
+        version: 4.1.2(@types/node@22.13.14)(jsdom@25.0.1)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
 
   core/internationalization/i18n:
     devDependencies:
@@ -212,7 +212,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 4.1.2
-        version: 4.1.2(@types/node@22.13.14)(jsdom@25.0.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
+        version: 4.1.2(@types/node@22.13.14)(jsdom@25.0.1)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
 
   core/web:
     devDependencies:
@@ -232,14 +232,14 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       vite:
-        specifier: 8.0.3
-        version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)
+        specifier: 8.0.6
+        version: 8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@22.13.14)(rollup@4.50.2)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
+        version: 4.5.4(@types/node@22.13.14)(rollup@4.50.2)(typescript@5.9.3)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
       vitest:
         specifier: 4.1.2
-        version: 4.1.2(@types/node@22.13.14)(jsdom@25.0.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
+        version: 4.1.2(@types/node@22.13.14)(jsdom@25.0.1)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
 
   docs:
     dependencies:
@@ -258,10 +258,10 @@ importers:
         version: 10.3.4(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.2.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@storybook/addon-docs':
         specifier: 10.3.4
-        version: 10.3.4(@types/react@19.2.10)(esbuild@0.27.2)(rollup@4.50.2)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.2.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
+        version: 10.3.4(@types/react@19.2.10)(esbuild@0.27.2)(rollup@4.50.2)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.2.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
       '@storybook/react-vite':
         specifier: 10.3.4
-        version: 10.3.4(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.50.2)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.2.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
+        version: 10.3.4(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.50.2)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.2.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
       '@types/react':
         specifier: 19.2.10
         version: 19.2.10
@@ -270,7 +270,7 @@ importers:
         version: 19.2.3(@types/react@19.2.10)
       '@vitejs/plugin-react':
         specifier: 6.0.1
-        version: 6.0.1(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
+        version: 6.0.1(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
       '@windows98/configs':
         specifier: workspace:*
         version: link:../core/configs
@@ -293,8 +293,8 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       vite:
-        specifier: 8.0.3
-        version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)
+        specifier: 8.0.6
+        version: 8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)
 
   micro-frontends:
     dependencies:
@@ -331,7 +331,7 @@ importers:
         version: 2.4.10
       '@playwright/experimental-ct-react':
         specifier: 1.59.1
-        version: 1.59.1(@types/node@22.13.14)(lightningcss@1.32.0)(sass@1.83.0)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))(yaml@2.8.3)
+        version: 1.59.1(@types/node@22.13.14)(lightningcss@1.32.0)(sass@1.83.0)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))(yaml@2.8.3)
       '@types/react':
         specifier: 19.2.10
         version: 19.2.10
@@ -340,7 +340,7 @@ importers:
         version: 19.2.3(@types/react@19.2.10)
       '@vitejs/plugin-react':
         specifier: 6.0.1
-        version: 6.0.1(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
+        version: 6.0.1(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
       '@windows98/configs':
         specifier: workspace:*
         version: link:../core/configs
@@ -357,17 +357,17 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       vite:
-        specifier: 8.0.3
-        version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)
+        specifier: 8.0.6
+        version: 8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)
       vite-plugin-css-injected-by-js:
         specifier: 4.0.1
-        version: 4.0.1(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
+        version: 4.0.1(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@22.13.14)(rollup@4.50.2)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
+        version: 4.5.4(@types/node@22.13.14)(rollup@4.50.2)(typescript@5.9.3)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
       vitest:
         specifier: 4.1.2
-        version: 4.1.2(@types/node@22.13.14)(jsdom@25.0.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
+        version: 4.1.2(@types/node@22.13.14)(jsdom@25.0.1)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
 
   micro-services:
     dependencies:
@@ -394,14 +394,14 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       vite:
-        specifier: 8.0.3
-        version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)
+        specifier: 8.0.6
+        version: 8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@22.13.14)(rollup@4.50.2)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
+        version: 4.5.4(@types/node@22.13.14)(rollup@4.50.2)(typescript@5.9.3)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
       vitest:
         specifier: 4.1.2
-        version: 4.1.2(@types/node@22.13.14)(jsdom@25.0.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
+        version: 4.1.2(@types/node@22.13.14)(jsdom@25.0.1)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
 
 packages:
 
@@ -671,14 +671,14 @@ packages:
     peerDependencies:
       postcss-selector-parser: ^7.1.1
 
-  '@emnapi/core@1.9.2':
-    resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
+  '@emnapi/core@1.9.1':
+    resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
 
-  '@emnapi/runtime@1.9.2':
-    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
+  '@emnapi/runtime@1.9.1':
+    resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
 
-  '@emnapi/wasi-threads@1.2.1':
-    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+  '@emnapi/wasi-threads@1.2.0':
+    resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
 
   '@esbuild/aix-ppc64@0.25.3':
     resolution: {integrity: sha512-W8bFfPA8DowP8l//sxjJLSLkD8iEjMc7cBVyP+u4cEv9sM7mdUCkgsj+t0n/BWPFtv7WWCN5Yzj0N6FJNUUqBQ==}
@@ -1060,8 +1060,8 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@oxc-project/types@0.122.0':
-    resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
+  '@oxc-project/types@0.123.0':
+    resolution: {integrity: sha512-YtECP/y8Mj1lSHiUWGSRzy/C6teUKlS87dEfuVKT09LgQbUsBW1rNg+MiJ4buGu3yuADV60gbIvo9/HplA56Ew==}
 
   '@parcel/watcher-android-arm64@2.5.1':
     resolution: {integrity: sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==}
@@ -1160,97 +1160,97 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.12':
-    resolution: {integrity: sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==}
+  '@rolldown/binding-android-arm64@1.0.0-rc.13':
+    resolution: {integrity: sha512-5ZiiecKH2DXAVJTNN13gNMUcCDg4Jy8ZjbXEsPnqa248wgOVeYRX0iqXXD5Jz4bI9BFHgKsI2qmyJynstbmr+g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
-    resolution: {integrity: sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==}
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.13':
+    resolution: {integrity: sha512-tz/v/8G77seu8zAB3A5sK3UFoOl06zcshEzhUO62sAEtrEuW/H1CcyoupOrD+NbQJytYgA4CppXPzlrmp4JZKA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.12':
-    resolution: {integrity: sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==}
+  '@rolldown/binding-darwin-x64@1.0.0-rc.13':
+    resolution: {integrity: sha512-8DakphqOz8JrMYWTJmWA+vDJxut6LijZ8Xcdc4flOlAhU7PNVwo2MaWBF9iXjJAPo5rC/IxEFZDhJ3GC7NHvug==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
-    resolution: {integrity: sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==}
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.13':
+    resolution: {integrity: sha512-4wBQFfjDuXYN/SVI8inBF3Aa+isq40rc6VMFbk5jcpolUBTe5cYnMsHZ51nFWsx3PVyyNN3vgoESki0Hmr/4BA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
-    resolution: {integrity: sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.13':
+    resolution: {integrity: sha512-JW/e4yPIXLms+jmnbwwy5LA/LxVwZUWLN8xug+V200wzaVi5TEGIWQlh8o91gWYFxW609euI98OCCemmWGuPrw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
-    resolution: {integrity: sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.13':
+    resolution: {integrity: sha512-ZfKWpXiUymDnavepCaM6KG/uGydJ4l2nBmMxg60Ci4CbeefpqjPWpfaZM7PThOhk2dssqBAcwLc6rAyr0uTdXg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
-    resolution: {integrity: sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==}
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.13':
+    resolution: {integrity: sha512-bmRg3O6Z0gq9yodKKWCIpnlH051sEfdVwt+6m5UDffAQMUUqU0xjnQqqAUm+Gu7ofAAly9DqiQDtKu2nPDEABA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
-    resolution: {integrity: sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==}
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.13':
+    resolution: {integrity: sha512-8Wtnbw4k7pMYN9B/mOEAsQ8HOiq7AZ31Ig4M9BKn2So4xRaFEhtCSa4ZJaOutOWq50zpgR4N5+L/opnlaCx8wQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
-    resolution: {integrity: sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==}
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.13':
+    resolution: {integrity: sha512-D/0Nlo8mQuxSMohNJUF2lDXWRsFDsHldfRRgD9bRgktj+EndGPj4DOV37LqDKPYS+osdyhZEH7fTakTAEcW7qg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
-    resolution: {integrity: sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==}
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.13':
+    resolution: {integrity: sha512-eRrPvat2YaVQcwwKi/JzOP6MKf1WRnOCr+VaI3cTWz3ZoLcP/654z90lVCJ4dAuMEpPdke0n+qyAqXDZdIC4rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
-    resolution: {integrity: sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==}
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.13':
+    resolution: {integrity: sha512-PsdONiFRp8hR8KgVjTWjZ9s7uA3uueWL0t74/cKHfM4dR5zXYv4AjB8BvA+QDToqxAFg4ZkcVEqeu5F7inoz5w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
-    resolution: {integrity: sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==}
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.13':
+    resolution: {integrity: sha512-hCNXgC5dI3TVOLrPT++PKFNZ+1EtS0mLQwfXXXSUD/+rGlB65gZDwN/IDuxLpQP4x8RYYHqGomlUXzpO8aVI2w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12':
-    resolution: {integrity: sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==}
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.13':
+    resolution: {integrity: sha512-viLS5C5et8NFtLWw9Sw3M/w4vvnVkbWkO7wSNh3C+7G1+uCkGpr6PcjNDSFcNtmXY/4trjPBqUfcOL+P3sWy/g==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
-    resolution: {integrity: sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.13':
+    resolution: {integrity: sha512-Fqa3Tlt1xL4wzmAYxGNFV36Hb+VfPc9PYU+E25DAnswXv3ODDu/yyWjQDbXMo5AGWkQVjLgQExuVu8I/UaZhPQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
-    resolution: {integrity: sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.13':
+    resolution: {integrity: sha512-/pLI5kPkGEi44TDlnbio3St/5gUFeN51YWNAk/Gnv6mEQBOahRBh52qVFVBpmrnU01n2yysvBML9Ynu7K4kGAQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -1258,8 +1258,8 @@ packages:
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
-  '@rolldown/pluginutils@1.0.0-rc.12':
-    resolution: {integrity: sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==}
+  '@rolldown/pluginutils@1.0.0-rc.13':
+    resolution: {integrity: sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==}
 
   '@rolldown/pluginutils@1.0.0-rc.7':
     resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
@@ -2883,8 +2883,8 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
-  rolldown@1.0.0-rc.12:
-    resolution: {integrity: sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==}
+  rolldown@1.0.0-rc.13:
+    resolution: {integrity: sha512-bvVj8YJmf0rq4pSFmH7laLa6pYrhghv3PRzrCdRAr23g66zOKVJ4wkvFtgohtPLWmthgg8/rkaqRHrpUEh0Zbw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -3223,14 +3223,14 @@ packages:
       yaml:
         optional: true
 
-  vite@8.0.3:
-    resolution: {integrity: sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==}
+  vite@8.0.6:
+    resolution: {integrity: sha512-jeOXoY6N8rOfit/mZADMd0misLqjRdWBB3/S23ZQNuPcbVsfMBJutWD8b4ftdczMOsNyMBnKro0Z1Kt0HIqq5Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
       '@vitejs/devtools': ^0.1.0
-      esbuild: ^0.27.0
+      esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
       less: ^4.0.0
       sass: ^1.70.0
@@ -3670,18 +3670,18 @@ snapshots:
     dependencies:
       postcss-selector-parser: 7.1.1
 
-  '@emnapi/core@1.9.2':
+  '@emnapi/core@1.9.1':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.1
+      '@emnapi/wasi-threads': 1.2.0
       tslib: 2.6.2
     optional: true
 
-  '@emnapi/runtime@1.9.2':
+  '@emnapi/runtime@1.9.1':
     dependencies:
       tslib: 2.6.2
     optional: true
 
-  '@emnapi/wasi-threads@1.2.1':
+  '@emnapi/wasi-threads@1.2.0':
     dependencies:
       tslib: 2.6.2
     optional: true
@@ -3839,11 +3839,11 @@ snapshots:
   '@esbuild/win32-x64@0.27.2':
     optional: true
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.9.3)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))':
     dependencies:
       glob: 13.0.6
       react-docgen-typescript: 2.2.2(typescript@5.9.3)
-      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)
+      vite: 8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -3917,10 +3917,10 @@ snapshots:
 
   '@microsoft/tsdoc@0.15.1': {}
 
-  '@napi-rs/wasm-runtime@1.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+  '@napi-rs/wasm-runtime@1.1.2(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)':
     dependencies:
-      '@emnapi/core': 1.9.2
-      '@emnapi/runtime': 1.9.2
+      '@emnapi/core': 1.9.1
+      '@emnapi/runtime': 1.9.1
       '@tybys/wasm-util': 0.10.1
     optional: true
 
@@ -3936,7 +3936,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
 
-  '@oxc-project/types@0.122.0': {}
+  '@oxc-project/types@0.123.0': {}
 
   '@parcel/watcher-android-arm64@2.5.1':
     optional: true
@@ -4035,10 +4035,10 @@ snapshots:
       - tsx
       - yaml
 
-  '@playwright/experimental-ct-react@1.59.1(@types/node@22.13.14)(lightningcss@1.31.1)(sass@1.83.0)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))(yaml@2.8.3)':
+  '@playwright/experimental-ct-react@1.59.1(@types/node@22.13.14)(lightningcss@1.31.1)(sass@1.83.0)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))(yaml@2.8.3)':
     dependencies:
       '@playwright/experimental-ct-core': 1.59.1(@types/node@22.13.14)(lightningcss@1.31.1)(sass@1.83.0)(yaml@2.8.3)
-      '@vitejs/plugin-react': 4.7.0(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
+      '@vitejs/plugin-react': 4.7.0(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -4054,10 +4054,10 @@ snapshots:
       - vite
       - yaml
 
-  '@playwright/experimental-ct-react@1.59.1(@types/node@22.13.14)(lightningcss@1.32.0)(sass@1.83.0)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))(yaml@2.8.3)':
+  '@playwright/experimental-ct-react@1.59.1(@types/node@22.13.14)(lightningcss@1.32.0)(sass@1.83.0)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))(yaml@2.8.3)':
     dependencies:
       '@playwright/experimental-ct-core': 1.59.1(@types/node@22.13.14)(lightningcss@1.32.0)(sass@1.83.0)(yaml@2.8.3)
-      '@vitejs/plugin-react': 4.7.0(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
+      '@vitejs/plugin-react': 4.7.0(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -4073,59 +4073,58 @@ snapshots:
       - vite
       - yaml
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.12':
+  '@rolldown/binding-android-arm64@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.12':
+  '@rolldown/binding-darwin-x64@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.13':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
+      '@emnapi/core': 1.9.1
+      '@emnapi/runtime': 1.9.1
+      '@napi-rs/wasm-runtime': 1.1.2(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.13':
     optional: true
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
-  '@rolldown/pluginutils@1.0.0-rc.12': {}
+  '@rolldown/pluginutils@1.0.0-rc.13': {}
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
 
@@ -4244,10 +4243,10 @@ snapshots:
       axe-core: 4.10.3
       storybook: 10.3.4(@testing-library/dom@10.4.0)(prettier@3.2.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  '@storybook/addon-docs@10.3.4(@types/react@19.2.10)(esbuild@0.27.2)(rollup@4.50.2)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.2.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))':
+  '@storybook/addon-docs@10.3.4(@types/react@19.2.10)(esbuild@0.27.2)(rollup@4.50.2)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.2.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))':
     dependencies:
       '@mdx-js/react': 3.0.1(@types/react@19.2.10)(react@19.2.4)
-      '@storybook/csf-plugin': 10.3.4(esbuild@0.27.2)(rollup@4.50.2)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.2.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
+      '@storybook/csf-plugin': 10.3.4(esbuild@0.27.2)(rollup@4.50.2)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.2.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
       '@storybook/icons': 2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@storybook/react-dom-shim': 10.3.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.2.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       react: 19.2.4
@@ -4261,25 +4260,25 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/builder-vite@10.3.4(esbuild@0.27.2)(rollup@4.50.2)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.2.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))':
+  '@storybook/builder-vite@10.3.4(esbuild@0.27.2)(rollup@4.50.2)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.2.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))':
     dependencies:
-      '@storybook/csf-plugin': 10.3.4(esbuild@0.27.2)(rollup@4.50.2)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.2.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
+      '@storybook/csf-plugin': 10.3.4(esbuild@0.27.2)(rollup@4.50.2)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.2.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
       storybook: 10.3.4(@testing-library/dom@10.4.0)(prettier@3.2.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ts-dedent: 2.2.0
-      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)
+      vite: 8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.3.4(esbuild@0.27.2)(rollup@4.50.2)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.2.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))':
+  '@storybook/csf-plugin@10.3.4(esbuild@0.27.2)(rollup@4.50.2)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.2.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))':
     dependencies:
       storybook: 10.3.4(@testing-library/dom@10.4.0)(prettier@3.2.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.2
       rollup: 4.50.2
-      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)
+      vite: 8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)
 
   '@storybook/global@5.0.0': {}
 
@@ -4294,11 +4293,11 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       storybook: 10.3.4(@testing-library/dom@10.4.0)(prettier@3.2.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  '@storybook/react-vite@10.3.4(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.50.2)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.2.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))':
+  '@storybook/react-vite@10.3.4(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.50.2)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.2.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
       '@rollup/pluginutils': 5.1.4(rollup@4.50.2)
-      '@storybook/builder-vite': 10.3.4(esbuild@0.27.2)(rollup@4.50.2)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.2.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
+      '@storybook/builder-vite': 10.3.4(esbuild@0.27.2)(rollup@4.50.2)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.2.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
       '@storybook/react': 10.3.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(@testing-library/dom@10.4.0)(prettier@3.2.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
@@ -4308,7 +4307,7 @@ snapshots:
       resolve: 1.22.8
       storybook: 10.3.4(@testing-library/dom@10.4.0)(prettier@3.2.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tsconfig-paths: 4.2.0
-      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)
+      vite: 8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -4416,7 +4415,7 @@ snapshots:
 
   '@types/resolve@1.20.6': {}
 
-  '@vitejs/plugin-react@4.7.0(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))':
+  '@vitejs/plugin-react@4.7.0(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
@@ -4424,14 +4423,14 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)
+      vite: 8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)
+      vite: 8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -4450,13 +4449,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.2(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.2(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)
+      vite: 8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -5699,29 +5698,26 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rolldown@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2):
+  rolldown@1.0.0-rc.13:
     dependencies:
-      '@oxc-project/types': 0.122.0
-      '@rolldown/pluginutils': 1.0.0-rc.12
+      '@oxc-project/types': 0.123.0
+      '@rolldown/pluginutils': 1.0.0-rc.13
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.12
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.12
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.12
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.12
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.12
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.12
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.12
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.12
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.12
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.12
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
+      '@rolldown/binding-android-arm64': 1.0.0-rc.13
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.13
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.13
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.13
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.13
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.13
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.13
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.13
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.13
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.13
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.13
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.13
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.13
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.13
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.13
 
   rollup@4.50.2:
     dependencies:
@@ -6048,11 +6044,11 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite-plugin-css-injected-by-js@4.0.1(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)):
+  vite-plugin-css-injected-by-js@4.0.1(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)):
     dependencies:
-      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)
+      vite: 8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)
 
-  vite-plugin-dts@4.5.4(@types/node@22.13.14)(rollup@4.50.2)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)):
+  vite-plugin-dts@4.5.4(@types/node@22.13.14)(rollup@4.50.2)(typescript@5.9.3)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)):
     dependencies:
       '@microsoft/api-extractor': 7.52.6(@types/node@22.13.14)
       '@rollup/pluginutils': 5.1.4(rollup@4.50.2)
@@ -6065,7 +6061,7 @@ snapshots:
       magic-string: 0.30.17
       typescript: 5.9.3
     optionalDependencies:
-      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)
+      vite: 8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
@@ -6101,12 +6097,12 @@ snapshots:
       sass: 1.83.0
       yaml: 2.8.3
 
-  vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3):
+  vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
       postcss: 8.5.8
-      rolldown: 1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      rolldown: 1.0.0-rc.13
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 22.13.14
@@ -6114,14 +6110,11 @@ snapshots:
       fsevents: 2.3.3
       sass: 1.83.0
       yaml: 2.8.3
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
 
-  vitest@4.1.2(@types/node@22.13.14)(jsdom@25.0.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)):
+  vitest@4.1.2(@types/node@22.13.14)(jsdom@25.0.1)(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.2
-      '@vitest/mocker': 4.1.2(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.2(vite@8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.2
       '@vitest/runner': 4.1.2
       '@vitest/snapshot': 4.1.2
@@ -6138,7 +6131,7 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)
+      vite: 8.0.6(@types/node@22.13.14)(esbuild@0.27.2)(sass@1.83.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.13.14


### PR DESCRIPTION
[![CI/CD](https://github.com/arkadiuszPasciak/windows98/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/arkadiuszPasciak/windows98/actions/workflows/ci-cd.yml)

### ❓ Type of change

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply. -->
<!-- Delete options that are not relevant. -->

- [x] 👌 Enhancement (improving an existing functionality like performance)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

Updates the monorepo’s Vite toolchain versions in lockstep across workspaces, keeping the PNPM enforcement hook aligned with the new pinned versions.

**Changes:**
- Bump `vite` from `8.0.3` → `8.0.6` across affected workspaces.
- Bump `vitest` from `4.1.2` → `4.1.3` across affected workspaces.
- Bump `lightningcss` from `1.31.1` → `1.32.0` and refresh `pnpm-lock.yaml` accordingly.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] Have you followed coding standards and best practices for the project?
- [x] Have you tested your changes?
- [x] Have you successfully run all tests?
- [x] Have you performed a self-review of your own code?
- [x] Have you ensured that your changes do not introduce any new security vulnerabilities?
